### PR TITLE
ci: skip hooks for release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           publish: bun run release
           commit: "chore(version): version packages"
         env:
+          HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What changed

- disable Husky hooks for the Changesets release action's automated commit

## Why

The release job successfully generated package versions, then failed while committing because `.husky/pre-commit` invoked `gitleaks`, which is not installed on the release runner. Automated release commits are validated by the pull request CI, so local developer hooks should not run in this step.

Failing job: https://github.com/howard86/turbo-monorepo-template/actions/runs/30218787299/job/89837444987

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check origin/main...HEAD`
- pre-push gates: Ultracite, TypeScript, build, tests, Knip, gitleaks